### PR TITLE
fix: reject if remoteEntry script fails to load

### DIFF
--- a/getDynamicScript.js
+++ b/getDynamicScript.js
@@ -38,6 +38,7 @@ export default function getDynamicScript(remoteModule) {
     element.onerror = () => {
       // eslint-disable-next-line no-console
       console.error(`Dynamic Script Error: ${remoteModule.path}`);
+      reject(new Error(`Dynamic Script Error: ${remoteModule.path}`));
     };
   });
 }


### PR DESCRIPTION
If the path to the remote container entry fails to load, allow the error to bubble up so that it can be detected by an ErrorBoundary